### PR TITLE
Add prepare script for npm github install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "browser": "./dist/browser/index.js",
   "types": "dist/cjs/index.d.ts",
   "scripts": {
+    "prepare": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rimraf dist/ && npm run build:node && npm run build:browser",
     "build:node": "tsc && tsc -p tsconfig.cjs.json",


### PR DESCRIPTION
Noticed that directly installing using npm i didn't actually seem to work, as the build was not run during install due to the lack of a prepare script. I've added a prepare script that just runs the build script, so that npm runs it during install.