### PR TITLE
Fixing token creation logic

### DIFF
--- a/src/IDL/pump-fun.json
+++ b/src/IDL/pump-fun.json
@@ -252,6 +252,10 @@
         {
           "name": "uri",
           "type": "string"
+        },
+        {
+          "name": "creator",
+          "type": "pubkey"
         }
       ]
     },

--- a/src/IDL/pump-fun.ts
+++ b/src/IDL/pump-fun.ts
@@ -231,6 +231,10 @@ export type PumpFun = {
         {
           name: "uri";
           type: "string";
+        },
+        {
+          name: "creator";
+          type: "pubkey";
         }
       ];
     },

--- a/src/pumpfun.ts
+++ b/src/pumpfun.ts
@@ -196,7 +196,7 @@ export class PumpFunSDK {
     );
 
     return this.program.methods
-      .create(name, symbol, uri)
+      .create(name, symbol, uri, creator)
       .accounts({
         mint: mint.publicKey,
         associatedBondingCurve: associatedBondingCurve,


### PR DESCRIPTION
On March 7, 2024 pumpfun updated their IDL for token creation which broke a lot of integrations. This fix provides the changes that need to be made to successfully allow token creation again. Enjoy!